### PR TITLE
make mono-run work

### DIFF
--- a/.github/workflows/check-packaging.yml
+++ b/.github/workflows/check-packaging.yml
@@ -1,20 +1,20 @@
-name: Check packaging
-on:
-  pull_request:
-  push:
-    branches:
-    - main
-jobs:
-  check-packaging:
-    name: Build and check the distribution package
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install test dependencies
-      run: |
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox-gh-actions
-    - name: Run tox
-      run: |
-        tox -e check-packaging
+# name: Check packaging
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#     - main
+# jobs:
+#   check-packaging:
+#     name: Build and check the distribution package
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Checkout repository
+#       uses: actions/checkout@v4
+#     - name: Install test dependencies
+#       run: |
+#         python3 -m pip install --upgrade pip setuptools
+#         python3 -m pip install tox-gh-actions
+#     - name: Run tox
+#       run: |
+#         tox -e check-packaging

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,20 +1,20 @@
-name: Static code analysis
-on:
-  pull_request:
-  push:
-    branches:
-    - main
-jobs:
-  lint:
-    name: Perform static analysis of the code
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-    - name: Install test dependencies
-      run: |
-        python3 -m pip install --upgrade pip setuptools
-        python3 -m pip install tox-gh-actions
-    - name: Run tox
-      run: |
-        tox -e lint
+# name: Static code analysis
+# on:
+#   pull_request:
+#   push:
+#     branches:
+#     - main
+# jobs:
+#   lint:
+#     name: Perform static analysis of the code
+#     runs-on: ubuntu-latest
+#     steps:
+#     - name: Checkout repository
+#       uses: actions/checkout@v4
+#     - name: Install test dependencies
+#       run: |
+#         python3 -m pip install --upgrade pip setuptools
+#         python3 -m pip install tox-gh-actions
+#     - name: Run tox
+#       run: |
+#         tox -e lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,76 +1,76 @@
-name: Publish wheel and source distributions to PyPI
-on:
-  push:
-    tags:
-    - '*'
+# name: Publish wheel and source distributions to PyPI
+# on:
+#   push:
+#     tags:
+#     - '*'
 
-jobs:
-  build_sdist:
-    name: Build source distribution
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-    - name: Build source distribution
-      run: |
-        python -m pip install build
-        python -m build
-    - name: Store them as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: sdist
-        path: dist/*.tar.gz
+# jobs:
+#   build_sdist:
+#     name: Build source distribution
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v4
+#     - name: Set up Python 3.12
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: 3.12
+#     - name: Build source distribution
+#       run: |
+#         python -m pip install build
+#         python -m build
+#     - name: Store them as artifact
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: sdist
+#         path: dist/*.tar.gz
 
-  build_wheel:
-    name: Build wheel
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.12
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
-    - name: Build distributions
-      run: |
-        python -m pip install build
-        python -m build --wheel
-    - name: Store them as artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wheel
-        path: dist/*.whl
+#   build_wheel:
+#     name: Build wheel
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v4
+#     - name: Set up Python 3.12
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: 3.12
+#     - name: Build distributions
+#       run: |
+#         python -m pip install build
+#         python -m build --wheel
+#     - name: Store them as artifact
+#       uses: actions/upload-artifact@v4
+#       with:
+#         name: wheel
+#         path: dist/*.whl
 
 
-  publish:
-    name: Publish distributions to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    needs:
-    - build_sdist
-    - build_wheel
-    environment:
-      name: publish_pypi
-      url: https://pypi.org/p/multiscale-run
-    permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-    steps:
-    - name: Download artifacts produced by the build_sdist job
-      uses: actions/download-artifact@v4
-      with:
-        name: sdist
-        path: dist/
-    - name: Download artifacts produced by the build_wheel job
-      uses: actions/download-artifact@v4
-      with:
-        name: wheel
-        path: dist/
-    - name: Display structure of downloaded files
-      run: ls -R
-      working-directory: dist
-    - name: Publish packages to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages_dir: dist/
+#   publish:
+#     name: Publish distributions to PyPI
+#     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+#     runs-on: ubuntu-latest
+#     needs:
+#     - build_sdist
+#     - build_wheel
+#     environment:
+#       name: publish_pypi
+#       url: https://pypi.org/p/multiscale-run
+#     permissions:
+#       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+#     steps:
+#     - name: Download artifacts produced by the build_sdist job
+#       uses: actions/download-artifact@v4
+#       with:
+#         name: sdist
+#         path: dist/
+#     - name: Download artifacts produced by the build_wheel job
+#       uses: actions/download-artifact@v4
+#       with:
+#         name: wheel
+#         path: dist/
+#     - name: Display structure of downloaded files
+#       run: ls -R
+#       working-directory: dist
+#     - name: Publish packages to PyPI
+#       uses: pypa/gh-action-pypi-publish@release/v1
+#       with:
+#         packages_dir: dist/

--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+juliaenv/
 
 # mkdocs documentation
 /site
@@ -91,3 +92,6 @@ cython_debug/
 
 # IDE
 .idea/
+
+# tests
+tiny_CI_test/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,68 @@
+
+## MultiscaleRun
+
+MultiscaleRun is a Python package to run brain cells simulation at different scales.
+It orchestrates the coupling between several brain simulators like Neuron and
+STEPS but also solvers like AstroVascPy for the cerebral blood flow.
+The package also embeds a Julia solver to simulate the astrocytes activity.
+
+The Python package includes a program called `multiscale-run` that lets you run
+and analyze multiscale simulations from start to finish.
+
+## Testing for Development
+
+### Prerequisites
+- have an OBI spack installation working: https://github.com/openbraininstitute/spack
+- install julia with juliaup (not strictly necessary but it is harder to remove than to leave as is)
+
+### Setup
+
+You just need to run `setup.sh` at least once before running the simulation.
+
+The script does this:
+- set various env variables
+- create a `spackenv` folder with the necessary dependencies
+- create a `julia` project with the necessary dependencies in `juliaenv`
+- create a python virtual env in `venv` 
+- call `pip install -e .` for development
+- create the test folder `tiny_CI_test`
+- fill it with the necessary data
+
+```bash
+source setup.sh
+```
+
+If a folder is present (`spackenv`, `venv`, `juliaenv`) the script skips that installation step assuming that is already done. If any of the folders are missing, the script redoes the setup. 
+
+The environemnt is still set as it is needed. 
+
+You can always modify them and recall `setup.sh`. It will not override your changes. 
+
+### Test
+
+You just need to go to `tiny_CI_test` and run. The simulation is too slow with just one core. I suggest at least 8 cores. Do not go above 90 for now as this leaves some cores without neurons (edge case that I did not check). 
+
+```bash
+cd tiny_CI_test
+mpirun -np 8 multiscale-run compute
+```
+
+## Authors
+
+Polina Shichkova, Alessandro Cattabiani, Christos Kotsalos, and Tristan Carel
+
+## Acknowledgment
+
+The development of this software was supported by funding to the Blue Brain Project,
+a research center of the École polytechnique fédérale de Lausanne (EPFL),
+from the Swiss government's ETH Board of the Swiss Federal Institutes of Technology.
+
+Copyright (c) 2005-2023 Blue Brain Project/EPFL
+Copyright (c) 2025 Open Brain Institute
+
+
+<!-- # THE FOLLOWING README IS OLD AND NEEDS TO BE UPDATED
+
 # MultiscaleRun [![PyPI version](https://badge.fury.io/py/multiscale-run.svg)](https://badge.fury.io/py/multiscale-run) [![Documentation Status](https://readthedocs.org/projects/multiscalerun/badge/?version=stable)](https://multiscalerun.readthedocs.io/stable/?badge=stable)
 
 MultiscaleRun is a Python package to run brain cells simulation at different scales.
@@ -254,14 +319,6 @@ For more on how to use ARM MAP on BB5, please check [this page](https://bbpteam.
 
 ## 0.1 - 2023-11-30
 
-First release of the code shipped as a Python package
+First release of the code shipped as a Python package -->
 
-## Authors
 
-Polina Shichkova, Alessandro Cattabiani, Christos Kotsalos, and Tristan Carel
-
-## Funding and Acknowledgments
-
-The development of this software was supported by funding to the Blue Brain Project, a research center of the École polytechnique fédérale de Lausanne (EPFL), from the Swiss government’s ETH Board of the Swiss Federal Institutes of Technology.
-
-Copyright (c) 2023-2024 Blue Brain Project/EPFL

--- a/multiscale_run/bloodflow_manager.py
+++ b/multiscale_run/bloodflow_manager.py
@@ -3,9 +3,6 @@ from collections import defaultdict
 
 import numpy as np
 import pandas as pd
-from astrovascpy import bloodflow
-from astrovascpy.utils import Graph, create_entry_largest_nodes
-from vascpy import PointVasculature
 
 from . import utils
 
@@ -115,6 +112,8 @@ class MsrBloodflowManager:
         Returns
             list: A list of bloodflow input nodes as node IDs.
         """
+        from astrovascpy.utils import create_entry_largest_nodes
+
         self.entry_nodes = create_entry_largest_nodes(
             graph=self.graph, params=self.parameters
         )
@@ -136,6 +135,9 @@ class MsrBloodflowManager:
             - The loaded vasculature graph is stored in the 'graph' attribute of the MsrBloodflowManager.
             - This method prepares the vasculature graph by setting edge data and creating a MultiIndex for edge properties based on section and segment IDs.
         """
+        from astrovascpy.utils import Graph
+        from vascpy import PointVasculature
+
         pv = PointVasculature.load_sonata(vasculature_path)
         self.graph = Graph.from_point_vasculature(pv)
 
@@ -155,6 +157,8 @@ class MsrBloodflowManager:
             - The calculated boundary flows are based on the input flow rate ('input_v') and the entry nodes in the vasculature graph.
             - The calculated boundary flows are stored in the 'boundary_flows' attribute.
         """
+        from astrovascpy import bloodflow
+
         input_flows = None
         if self.entry_nodes is not None:
             input_flows = [self.parameters["input_v"]] * len(self.entry_nodes)
@@ -174,6 +178,8 @@ class MsrBloodflowManager:
               updated flow and volume properties for the vasculature.
             - It is typically used in the context of multiscale simulations involving blood flow.
         """
+        from astrovascpy import bloodflow
+
         bloodflow.update_static_flow_pressure(
             graph=self.graph,
             input_flow=self.boundary_flows,

--- a/multiscale_run/config.py
+++ b/multiscale_run/config.py
@@ -9,7 +9,8 @@ import jsonschema
 import numpy as np
 
 from . import utils
-from .templates import MSR_CONFIG_JSON, MSR_PKG_DIR, MSR_SCHEMA_JSON, TEMPLATES_DIR
+from .templates import (MSR_CONFIG_JSON, MSR_PKG_DIR, MSR_SCHEMA_JSON,
+                        TEMPLATES_DIR)
 
 
 class NamedCircuit(

--- a/multiscale_run/metabolism_manager.py
+++ b/multiscale_run/metabolism_manager.py
@@ -212,10 +212,8 @@ class MsrMetabolismManager:
             the calculated glycogen value, and mito_volume_fraction is
             the calculated mitochondrial volume fraction.
         """
-        # idx: layers are 1-based while python vectors are 0-based
-        # c_gid: ndam is 1-based while libsonata and bluepysnap are 0-based
-
-        idx = int(self.neuron_node_pop.get_attribute("layer", raw_gid - 1)) - 1
+        # layer_idx: layers are 1-based while python vectors are 0-based
+        layer_idx = int(self.neuron_node_pop.get_attribute("layer", raw_gid)) - 1
         glycogen_au = np.array(
             self.config.multiscale_run.metabolism.constants.glycogen_au
         )
@@ -227,8 +225,8 @@ class MsrMetabolismManager:
             1.0 / max(mito_volume_fraction)
         )
         return (
-            glycogen_scaled[idx],
-            mito_volume_fraction_scaled[idx],
+            glycogen_scaled[layer_idx],
+            mito_volume_fraction_scaled[layer_idx],
         )
 
     @utils.logs_decorator

--- a/multiscale_run/neurodamus_manager.py
+++ b/multiscale_run/neurodamus_manager.py
@@ -20,6 +20,7 @@ class MsrNeurodamusManager:
             config: The configuration for the neurodamus manager.
         """
         logging.info("instantiate ndam")
+
         self.ndamus = neurodamus.Neurodamus(
             str(config.config_path),
             logging_level=config.multiscale_run.logging_level,
@@ -321,10 +322,16 @@ class MsrNeurodamusManager:
 
             logging.info(f"Working GIDs to Total GIDs Ratio:\n{', '.join(ratios)}")
 
-            logging.info("GIDs that failed:")
-            for r, removal_reasons in enumerate(removed_gids):
-                for gid, reason in removal_reasons.items():
-                    logging.info(f"Rank {r}, GID {gid}: {reason}")
+            any_failed = any(
+                len(removal_reasons) > 0 for removal_reasons in removed_gids
+            )
+            if any_failed:
+                logging.info("GIDs that failed:")
+                for r, removal_reasons in enumerate(removed_gids):
+                    for gid, reason in removal_reasons.items():
+                        logging.info(f"Rank {r}, GID {gid}: {reason}")
+            else:
+                logging.info("No failed GIDs")
 
             if sum(working_gids) == 0:
                 raise utils.MsrException(

--- a/multiscale_run/preprocessor.py
+++ b/multiscale_run/preprocessor.py
@@ -2,11 +2,9 @@ import json
 import logging
 from pathlib import Path
 
-import gmsh
 import libsonata
 import numpy as np
 import pandas as pd
-import trimesh
 
 from . import utils
 
@@ -242,6 +240,8 @@ class MsrPreprocessor:
             >>> points = np.array([[x1, y1, z1], [x2, y2, z2], ...])
             >>> gen_stl_and_geo(points)
         """
+        import trimesh
+
         point_cloud = trimesh.PointCloud(points)
         surface_mesh = point_cloud.convex_hull
 
@@ -332,6 +332,7 @@ Volume(1) = {{1}};
 
 Physical Volume("{phys_vol}", 1) = {{1}};
         """
+        import gmsh
 
         mesh_path = self.config.multiscale_run.mesh_path
         with open(str(mesh_path.with_suffix(".geo")), "w") as geo_file:
@@ -380,6 +381,8 @@ Physical Volume("{phys_vol}", 1) = {{1}};
         Example:
             >>> gen_msh()
         """
+        import gmsh
+
         script_file = str(self.config.multiscale_run.mesh_path.with_suffix(".geo"))
         output_file = str(self.config.multiscale_run.mesh_path.with_suffix(".msh"))
         refinement_steps = self.config.multiscale_run.preprocessor.mesh.refinement_steps
@@ -469,6 +472,8 @@ Physical Volume("{phys_vol}", 1) = {{1}};
     @property
     def ntets(self):
         """Count the total number of tets in the mesh"""
+        import gmsh
+
         gmsh.initialize()
         try:
             gmsh.open(str(self.config.multiscale_run.mesh_path))

--- a/multiscale_run/simulation.py
+++ b/multiscale_run/simulation.py
@@ -50,14 +50,10 @@ class MsrSimulation:
         import neurodamus  # noqa: F401
 
         # steps_manager should go before preprocessor until https://github.com/CNS-OIST/HBP_STEPS/issues/1166 is solved
-        from multiscale_run import (  # noqa: F401
-            bloodflow_manager,
-            connection_manager,
-            metabolism_manager,
-            neurodamus_manager,
-            preprocessor,
-            steps_manager,
-        )
+        from multiscale_run import (bloodflow_manager,  # noqa: F401
+                                    connection_manager, metabolism_manager,
+                                    neurodamus_manager, preprocessor,
+                                    steps_manager)
 
     @_run_once
     def configure(self):
@@ -80,17 +76,12 @@ class MsrSimulation:
         self.configure()
         logging.info("Initialize simulation")
         if self.conf.is_metabolism_active():
-            from diffeqpy import de
             from julia import Main as JMain
         from neurodamus.utils.timeit import timeit
 
-        from multiscale_run import (
-            bloodflow_manager,
-            metabolism_manager,
-            neurodamus_manager,
-            reporter,
-            steps_manager,
-        )
+        from multiscale_run import (bloodflow_manager, metabolism_manager,
+                                    neurodamus_manager, reporter,
+                                    steps_manager)
 
         with timeit(name="initialization"):
             self.prep.autogen_node_sets()
@@ -150,9 +141,11 @@ class MsrSimulation:
             self.rep = reporter.MsrReporter(
                 config=self.conf,
                 gids=self.neurodamus_manager.gids(),
-                n_bf_segs=self.managers["bloodflow"].n_segs
-                if self.conf.is_bloodflow_active()
-                else 0,
+                n_bf_segs=(
+                    self.managers["bloodflow"].n_segs
+                    if self.conf.is_bloodflow_active()
+                    else 0
+                ),
             )
 
             # apply all the connections for initialization
@@ -208,6 +201,7 @@ class MsrSimulation:
         time_steps = msr_utils.timesteps(
             self.conf.run.tstop, self.conf.multiscale_run_dt
         )
+
         for t in ProgressBar(time_step_n)(time_steps):
             i_ndam += self.conf.multiscale_run.ndts
             with timeit(name="main_loop"):

--- a/multiscale_run/steps_manager.py
+++ b/multiscale_run/steps_manager.py
@@ -4,15 +4,15 @@ import time
 from pathlib import Path
 
 import numpy as np
-import steps.interface
+# import steps.interface
 from scipy import constants as spc
 from scipy import sparse
-from steps.geom import *
-from steps.model import *
-from steps.rng import *
-from steps.saving import *
-from steps.sim import *
-from steps.utils import *
+# from steps.geom import *
+# from steps.model import *
+# from steps.rng import *
+# from steps.saving import *
+# from steps.sim import *
+# from steps.utils import *
 from tqdm import tqdm
 
 from . import utils

--- a/multiscale_run/templates/__init__.py
+++ b/multiscale_run/templates/__init__.py
@@ -17,6 +17,4 @@ _jinja_env = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
 
 SBATCH_TEMPLATE = _jinja_env.get_template("simulation.sbatch.jinja")
 
-BB5_JULIA_ENV = Path(
-    "/gpfs/bbp.cscs.ch/project/proj12/jenkins/subcellular/multiscale_run/julia-environment/latest"
-)
+JULIA_ENV = Path("~").expanduser()

--- a/multiscale_run/templates/tiny_CI/simulation_config.json
+++ b/multiscale_run/templates/tiny_CI/simulation_config.json
@@ -1,8 +1,8 @@
 {
     "multiscale_run": {
-        "with_steps": true,
-        "with_bloodflow": true,
-        "with_metabolism": true,
+        "with_steps": false,
+        "with_bloodflow": false,
+        "with_metabolism": false,
         "cache_save": true,
         "cache_load": true,
         "logging_level": 1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,8 @@ requires = [
     "wheel>=0.41",
 ]
 
-[tool.setuptools]
-packages = [
-    "multiscale_run",
-    "multiscale_run.templates",
-]
+[tool.setuptools.packages.find]
+include = ["multiscale_run*"]
 
 [tool.setuptools_scm]
 
@@ -23,7 +20,10 @@ filterwarnings = [
 [project]
 name = "multiscale_run"
 authors = [
-    {name = "Blue Brain Project, EPFL", email = "bbp.opensource@epfl.ch" }
+    {name = "Blue Brain Project, EPFL"}
+]
+maintainers = [
+  { name = "Open Brain Institute" }
 ]
 description = """
     MultiscaleRun is a Python package to run brain cells simulation at different scales. \
@@ -43,11 +43,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "astrovascpy>=0.1.5",
+    # "astrovascpy>=0.1.5",
     "diffeqpy>=1.1",
-    "gmsh>=4.2",
-    "jinja2>=3",
-    "jsonschema>=4",
+    # "gmsh>=4.2",
+    # "jinja2>=3",
+    # "jsonschema>=4",
     "julia>=0.6, <0.7",
     "libsonata>=0.1.20",
     "mpi4py>=3",
@@ -58,7 +58,7 @@ dependencies = [
     "scipy>=1.11.1",
     "simpleeval>=0.9.13",
     "tqdm>=4.65",
-    "trimesh>=3",
+    # "trimesh>=3",
 ]
 dynamic = ["version"]
 
@@ -78,13 +78,12 @@ multiscale-run = "multiscale_run.cli:main"
 
 [project.urls]
 Homepage = "https://multiscalerun.rtfd.io"
-Source = "https://github.com/BlueBrain/MultiscaleRun.git"
-Tracker = "https://github.com/BlueBrain/MultiscaleRun/issues"
+Source = "https://github.com/openbraininstitute/MultiscaleRun.git"
+Tracker = "https://github.com/openbraininstitute/MultiscaleRun/issues"
 
 [tool.ruff]
 # Same as Black.
-line-length = 88
-indent-width = 4
+line-length = 100
 
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I"]

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,104 @@
+# !/usr/bin/env bash
+
+test_folder="tiny_CI_test"
+
+# libsoantareport
+
+export LIBSONATA_ZERO_BASED_GIDS=1
+
+# spack
+
+if [ -d "spackenv" ]; then
+  echo "Found existing spackenv directory. Just load env"
+  spack env activate -d spackenv
+else
+  spack env create -d spackenv
+  spack env activate -d spackenv
+  spack add neurodamus-models@develop+ngv+metabolism model=neocortex
+  spack add py-neurodamus@develop
+  spack add openmpi
+  spack concretize -f
+  spack install
+  spack env deactivate
+  spack env activate -d spackenv
+fi
+
+# julia
+
+JULIAENV_DIR="juliaenv"
+export PYTHON=$(which python3)
+export JULIA_NUM_THREADS=1
+export JULIA_DEPOT_PATH="$PWD/$JULIAENV_DIR"
+export JULIAUP_DEPOT_PATH="$JULIA_DEPOT_PATH"
+export JULIA_PROJECT="$PWD/juliaenv"
+
+# Skip setup if the environment already exists
+if [ -d "$JULIAENV_DIR" ]; then
+  echo "✓ Julia environment already exists at '$JULIAENV_DIR'. Skipping setup."
+else
+  mkdir -p "$JULIAENV_DIR"
+  
+  julia --color=yes -e "
+using Pkg
+
+# Activate environment
+Pkg.activate(\"$JULIAENV_DIR\")
+
+println(\"→ Installing Julia packages...\")
+
+# Add required packages
+for pkg in [\"IJulia\", \"PyCall\", \"StructUtils\", \"PythonCall\", \"DifferentialEquations\"]
+    Pkg.add(pkg)
+end
+
+# Ensure environment is synced
+Pkg.instantiate(verbose=true)
+
+# Build packages with compiled extensions
+Pkg.build(\"StructUtils\")
+
+# Retry loading compiled extensions
+Base.retry_load_extensions()
+
+# Precompile all packages
+Pkg.precompile()
+
+println(\"✓ Julia packages installation complete.\")
+"
+fi
+
+
+# python
+
+if [ -d "venv" ]; then
+  echo "Found existing venv directory. Just load env"
+  source venv/bin/activate
+else
+  python -m venv venv
+  source venv/bin/activate
+  pip install --upgrade pip
+  pip install -e . # this should have pyjulia inside
+  python -c "import julia; julia.install()"
+  python -c "from diffeqpy import de"
+fi
+
+# set new test
+
+if [ ! -d "$test_folder" ]; then
+  multiscale-run init "$test_folder" --circuit=tiny_CI
+  cd $test_folder
+  source ../.ci/setup.sh
+  download_tiny_CI_neurodamus_data
+  cd ..
+fi
+
+# # manually edit set simplation_config.json
+
+# # run
+
+# # multiscale-run compute
+
+
+
+
+

--- a/tests/integration/autogen_mesh.py
+++ b/tests/integration/autogen_mesh.py
@@ -3,12 +3,7 @@ from pathlib import Path
 import numpy as np
 from neuron import h
 
-from multiscale_run import (
-    MsrConfig,
-    MsrPreprocessor,
-    MsrStepsManager,
-    utils,
-)
+from multiscale_run import MsrConfig, MsrPreprocessor, MsrStepsManager, utils
 
 
 def base_path():

--- a/tests/integration/connect_neurodamus2steps.py
+++ b/tests/integration/connect_neurodamus2steps.py
@@ -3,14 +3,9 @@
 import numpy as np
 from neuron import h
 
-from multiscale_run import (
-    MsrConfig,
-    MsrConnectionManager,
-    MsrNeurodamusManager,
-    MsrPreprocessor,
-    MsrStepsManager,
-    utils,
-)
+from multiscale_run import (MsrConfig, MsrConnectionManager,
+                            MsrNeurodamusManager, MsrPreprocessor,
+                            MsrStepsManager, utils)
 
 
 def check_ratio_mat(m):

--- a/tests/integration/preprocessor.py
+++ b/tests/integration/preprocessor.py
@@ -1,12 +1,7 @@
 from neuron import h
 
-from multiscale_run import (
-    MsrBloodflowManager,
-    MsrConfig,
-    MsrNeurodamusManager,
-    MsrPreprocessor,
-    utils,
-)
+from multiscale_run import (MsrBloodflowManager, MsrConfig,
+                            MsrNeurodamusManager, MsrPreprocessor, utils)
 
 
 @utils.pushtempd

--- a/tests/pytests/test_cli.py
+++ b/tests/pytests/test_cli.py
@@ -11,7 +11,7 @@ import pytest
 
 from multiscale_run import utils
 from multiscale_run.cli import argument_parser, main
-from multiscale_run.templates import BB5_JULIA_ENV
+from multiscale_run.templates import JULIA_ENV
 
 
 def test_init_without_metabolism(tmp_path):
@@ -32,7 +32,7 @@ def test_init_without_metabolism(tmp_path):
         raise KeyError(str(e) + "\nJSON config is missing a mandatory key")
 
 
-@pytest.mark.skipif(not BB5_JULIA_ENV.exists(), reason="BB5 resources required")
+@pytest.mark.skipif(not JULIA_ENV.exists(), reason="BB5 resources required")
 def test_init_twice(tmp_path):
     sim_path = tmp_path / "sim"
 
@@ -179,7 +179,7 @@ def test_edit_mod_files(tmp_path):
         == 0
     )
     build_cmd = "build_neurodamus.sh mod --only-neuron"
-    if BB5_JULIA_ENV.exists and intel_compiler:
+    if JULIA_ENV.exists and intel_compiler:
         build_cmd = "module load unstable intel-oneapi-compilers ; " + build_cmd
     subprocess.check_call(build_cmd, shell=True, cwd=path)
 


### PR DESCRIPTION
fix #3 

## Context

MultiscaleRun was heavily dependent on bb5. Its loss made the program fail in various parts. Here I want to start from the base and rebuild from the ground up checking with the `tiny_CI` circuit. The only circuit I was able to save for posterity. 

It is too slow to run on a single core. We will employ mpirun

## Scope

- remove bloodflow dependencies
- remove steps dependencies
-  fix spack installation problems
- leave julia for now, remove diffeqpy as it is problematic
- the latest release of `neurodamus-models` gives a seg-fault for glu2 and cadifus. We should use develop
- add `setup.py` to set spack, python and prepare the tiny_CI simulation
- remove ci. I will reactivate once something works. It is less important now
- update readme
- add the testing in the readme
  
 ## Testing

@jamesgking check the testing section in the readme